### PR TITLE
Added boolean radio buttons

### DIFF
--- a/bool-rad-buttons.html
+++ b/bool-rad-buttons.html
@@ -1,0 +1,18 @@
+<template name="afBooleanRadioGroup_buttonGroup">
+    <div class="btn-group af-radio-group" data-toggle="buttons" {{dsk}}>
+        <label class="btn btn-default {{#if isTrue}}active{{/if}}">
+            <input type="radio" value="true"  {{trueAtts}} name="{{this.name}}" />
+          {{#with this.atts.trueLabel}}{{this}}{{else}}True{{/with}}
+        </label>
+        <label class="btn btn-default {{#if isFalse}}active{{/if}}">
+            <input type="radio" value="false"  {{falseAtts}} name="{{this.name}}" />
+          {{#with this.atts.falseLabel}}{{this}}{{else}}False{{/with}}
+        </label>
+      {{#with this.atts.nullLabel}}
+          <label class="btn btn-default {{#if isNull}}active{{/if}}">
+              <input type="radio" value="" name="{{../name}}" {{nullAtts}} />
+            {{this}}
+          </label>
+      {{/with}}
+    </div>
+</template>

--- a/bool-rad-buttons.js
+++ b/bool-rad-buttons.js
@@ -1,0 +1,35 @@
+Template["afBooleanRadioGroup_buttonGroup"].helpers({
+  falseAtts: function falseAtts() {
+    var atts = _.omit(this.atts, 'trueLabel', 'falseLabel', 'nullLabel', 'data-schema-key');
+    if (this.value === false) {
+      atts.checked = "";
+    }
+    return atts;
+  },
+  trueAtts: function trueAtts() {
+    var atts = _.omit(this.atts, 'trueLabel', 'falseLabel', 'nullLabel', 'data-schema-key');
+    if (this.value === true) {
+      atts.checked = "";
+    }
+    return atts;
+  },
+  nullAtts: function nullAtts() {
+    var atts = _.omit(this.atts, 'trueLabel', 'falseLabel', 'nullLabel', 'data-schema-key');
+    if (this.value !== true && this.value !== false) {
+      atts.checked = "";
+    }
+    return atts;
+  },
+  isTrue: function () {
+    return this.value === true;
+  },
+  isFalse: function () {
+    return this.value === false;
+  },
+  isNull: function () {
+    return this.value !== true && this.value !== false;
+  },
+  dsk: function () {
+    return {'data-schema-key': this.atts['data-schema-key']};
+  }
+});

--- a/package.js
+++ b/package.js
@@ -13,6 +13,8 @@ Package.onUse(function(api) {
     'cb-buttons.html',
     'cb-buttons.js',
     'rad-buttons.html',
-    'rad-buttons.js'
+    'rad-buttons.js',
+    'bool-rad-buttons.html',
+    'bool-rad-buttons.js'
   ], 'client');
 });


### PR DESCRIPTION
Added boolean radio buttons (related to issue #3).

I'm using it in production, and it works fine. I've used the same structure than the official boolean radio buttons for the helpers: https://github.com/aldeed/meteor-autoform/tree/devel/inputTypes/boolean-radios
